### PR TITLE
Fix 502 errors

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -37,23 +37,21 @@ public interface RoutingGroupSelector {
     RulesEngine rulesEngine = new DefaultRulesEngine();
     MVELRuleFactory ruleFactory = new MVELRuleFactory(new YamlRuleDefinitionReader());
 
-    return request -> {
-      try {
-        Rules rules = ruleFactory.createRules(
-            new FileReader(rulesConfigPath));
+    try {
+      Rules rules = ruleFactory.createRules(new FileReader(rulesConfigPath));
+      return request -> {
         Facts facts = new Facts();
         HashMap<String, String> result = new HashMap<String, String>();
         facts.put("request", request);
         facts.put("result", result);
         rulesEngine.fire(rules, facts);
         return result.get("routingGroup");
-      } catch (Exception e) {
-        Logger.log.error("Error opening rules configuration file,"
-            + " using routing group header as default.", e);
-        return Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER))
-          .orElse(request.getHeader(ALTERNATE_ROUTING_GROUP_HEADER));
-      }
-    };
+      };
+    } catch (Exception e) {
+      Logger.log.error("Error opening rules configuration file,"
+          + " using routing group header as default.", e);
+      return byRoutingGroupHeader();
+    }
   }
 
   /**

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -82,41 +82,4 @@ public class TestRoutingGroupSelector {
         routingGroupSelector.findRoutingGroup(mockRequest), null);
   }
 
-  public void testByRoutingRulesEngineFileChange() throws Exception {
-    File file = File.createTempFile("routing_rules", ".yml");
-
-    FileWriter fw = new FileWriter(file);
-    fw.write(
-        "---\n"
-        + "name: \"airflow\"\n"
-        + "description: \"if query from airflow, route to etl group\"\n"
-        + "condition: \"request.getHeader(\\\"X-Trino-Source\\\") == \\\"airflow\\\"\"\n"
-        + "actions:\n"
-        + "  - \"result.put(\\\"routingGroup\\\", \\\"etl\\\")\"");
-    fw.close();
-
-    RoutingGroupSelector routingGroupSelector =
-        RoutingGroupSelector.byRoutingRulesEngine(file.getPath());
-
-    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-
-    when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
-    Assert.assertEquals(
-        routingGroupSelector.findRoutingGroup(mockRequest), "etl");
-
-    fw = new FileWriter(file);
-    fw.write(
-        "---\n"
-        + "name: \"airflow\"\n"
-        + "description: \"if query from airflow, route to etl group\"\n"
-        + "condition: \"request.getHeader(\\\"X-Trino-Source\\\") == \\\"airflow\\\"\"\n"
-        + "actions:\n"
-        + "  - \"result.put(\\\"routingGroup\\\", \\\"etl2\\\")\""); // change from etl to etl2
-    fw.close();
-
-    when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
-    Assert.assertEquals(
-        routingGroupSelector.findRoutingGroup(mockRequest), "etl2");
-    file.deleteOnExit();
-  }
 }


### PR DESCRIPTION
Gateway 502 errors have been causing a lot of incidents, particularly with the brand-transactions data-plane. This is issue has been reported on the main fork https://github.com/lyft/presto-gateway/issues/166, seems to manifest with concurrent requests. 

I think it's caused by initialising the `MVELRuleFactory` once, but then loading the rules into it per request (potentially across different threads).  I'm changing the code here to load the rules config once, not per request. This means that you'll have to restart the server to change the rules, but IMO that is the expected behaviour for config files, not hot reloading. 
